### PR TITLE
feat 10: getJobById()

### DIFF
--- a/src/main/java/se/sprinta/headhunterbackend/job/JobController.java
+++ b/src/main/java/se/sprinta/headhunterbackend/job/JobController.java
@@ -66,6 +66,13 @@ public class JobController {
         Job foundJob = this.jobService.findById(id);
         JobDtoView JobDtoView = this.jobToJobDtoViewConverter.convert(foundJob);
         return new Result(true, StatusCode.SUCCESS, "Find One Success", JobDtoView);
+
+    }
+
+    @GetMapping("/getJobById/{id}")
+    public Result getJobById(@PathVariable Long id) {
+        JobDtoView JobDtoView = this.jobService.getJobById(id);
+        return new Result(true, StatusCode.SUCCESS, "Find One Success", JobDtoView);
     }
 
     @PutMapping("/update/{id}")

--- a/src/main/java/se/sprinta/headhunterbackend/job/JobRepository.java
+++ b/src/main/java/se/sprinta/headhunterbackend/job/JobRepository.java
@@ -3,9 +3,11 @@ package se.sprinta.headhunterbackend.job;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+import se.sprinta.headhunterbackend.job.dto.JobDtoView;
 import se.sprinta.headhunterbackend.job.dto.JobsTitleAndIdDtoView;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Repository for Job objects
@@ -22,6 +24,9 @@ public interface JobRepository extends JpaRepository<Job, Long> {
      */
 
     List<Job> findAllByUser_Email(String email);
+
+    @Query("SELECT new se.sprinta.headhunterbackend.job.dto.JobDtoView(j.title, j.description) FROM Job j WHERE j.id = :jobId")
+    Optional<JobDtoView> getJobById(Long jobId);
 
     @Query("SELECT new se.sprinta.headhunterbackend.job.dto.JobsTitleAndIdDtoView(j.id, j.title) FROM Job j WHERE j.user.email = :email")
     List<JobsTitleAndIdDtoView> getJobTitles(String email);

--- a/src/main/java/se/sprinta/headhunterbackend/job/JobService.java
+++ b/src/main/java/se/sprinta/headhunterbackend/job/JobService.java
@@ -11,6 +11,7 @@ import se.sprinta.headhunterbackend.client.chat.dto.ChatResponse;
 import se.sprinta.headhunterbackend.client.chat.dto.Message;
 import se.sprinta.headhunterbackend.job.dto.JobDtoFormAdd;
 import se.sprinta.headhunterbackend.job.dto.JobDtoFormUpdate;
+import se.sprinta.headhunterbackend.job.dto.JobDtoView;
 import se.sprinta.headhunterbackend.job.dto.JobsTitleAndIdDtoView;
 import se.sprinta.headhunterbackend.system.exception.DoesNotExistException;
 import se.sprinta.headhunterbackend.system.exception.ObjectNotFoundException;
@@ -63,6 +64,11 @@ public class JobService {
     public Job findById(Long id) {
         return this.jobRepository.findById(id)
                 .orElseThrow(() -> new ObjectNotFoundException("job", id));
+    }
+
+    public JobDtoView getJobById(Long id) {
+        return this.jobRepository.getJobById(id).
+                orElseThrow(() -> new ObjectNotFoundException("job", id));
     }
 
 

--- a/src/main/java/se/sprinta/headhunterbackend/job/converter/JobToJobDtoViewConverter.java
+++ b/src/main/java/se/sprinta/headhunterbackend/job/converter/JobToJobDtoViewConverter.java
@@ -23,12 +23,8 @@ public class JobToJobDtoViewConverter
     @Override
     public JobDtoView convert(Job source) {
         return new JobDtoView(
-                source.getId(),
                 source.getTitle(),
-                source.getDescription(),
-                source.getUser().getEmail(),
-                source.getInstruction(),
-                source.getNumberOfAds()
+                source.getDescription()
         );
     }
 }

--- a/src/main/java/se/sprinta/headhunterbackend/job/dto/JobDtoView.java
+++ b/src/main/java/se/sprinta/headhunterbackend/job/dto/JobDtoView.java
@@ -3,24 +3,16 @@ package se.sprinta.headhunterbackend.job.dto;
 /**
  * Input Job data format for identifying a job and values that the job should be updated with.
  * Excludes ads field (ManyToOne-relation) to prevent recursion:
- *      Instead, numberOfAds represents the amount of ads that the job holds.
+ * Instead, numberOfAds represents the amount of ads that the job holds.
+ * <p>
  *
- * @param id The id of the job.
- * @param title The title of the job.
+ * @param title       The title of the job.
  * @param description The description of the job that is being used by the AI to generate an ad.
- * @param email The email of the user that holds the job.
- *              Relationship: [Job] *...1 [User]
- * @param instruction The instruction of the job that is being used by the AI to handle the description of the Job in order to create an ad.
- * @param numberOfAds The number of Ad objects that the Job object holds.
  */
 
 public record JobDtoView(
-        Long id,
         String title,
-        String description,
-        String email,
-        String instruction,
-        int numberOfAds
+        String description
 ) {
 }
 


### PR DESCRIPTION
findById() for jobs returns the entire entity. Filtering the entire table in backend to a DTO is an antipattern (or so I heard).

Using JPQL query, only the relevant columns are returned. The Optional return is used so that existing exception handling can be used. The existing JobDtoView is slimmed to only title and description. The old findById() is kept for testing purposes.