### PR TITLE
feat: getEmailUnique

### DIFF
--- a/src/main/java/se/sprinta/headhunterbackend/account/AccountController.java
+++ b/src/main/java/se/sprinta/headhunterbackend/account/AccountController.java
@@ -44,10 +44,10 @@ public class AccountController {
         return new Result(true, StatusCode.SUCCESS, "Find All Success", foundAccountDtos);
     }
 
-    @GetMapping("/isEmailAvailable/{email}")
-    public Result isEmailAvailable(@PathVariable String email) {
-        boolean isEmailAvailable = this.accountService.isEmailAvailable(email);
-        return new Result(true, StatusCode.SUCCESS, "Email checked", isEmailAvailable);
+    @GetMapping("/checkEmailUnique/{email}")
+    public Result checkEmailUnique(@PathVariable String email) {
+        this.accountService.checkEmailUnique(email);
+        return new Result(true, StatusCode.SUCCESS, "Email is available");
     }
 
     @GetMapping("/getAccountDtoByEmail/{userEmail}")

--- a/src/main/java/se/sprinta/headhunterbackend/account/AccountRepository.java
+++ b/src/main/java/se/sprinta/headhunterbackend/account/AccountRepository.java
@@ -25,7 +25,7 @@ public interface AccountRepository extends JpaRepository<Account, String> {
     Optional<Account> findAccountByEmail(String email);
 
     @Query("SELECT COUNT(ac) = 0 FROM Account ac WHERE ac.email = :email")
-    boolean isEmailAvailable(String email);
+    boolean checkEmailUnique(String email);
 
     @Query("SELECT new se.sprinta.headhunterbackend.account.dto.AccountDtoView(ac.email, ac.roles, ac.number_of_jobs) FROM Account ac where ac.email = :email")
     Optional<AccountDtoView> getAccountDtoByEmail(String email);

--- a/src/main/java/se/sprinta/headhunterbackend/account/AccountService.java
+++ b/src/main/java/se/sprinta/headhunterbackend/account/AccountService.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Service;
 import se.sprinta.headhunterbackend.account.dto.AccountDtoFormRegister;
 import se.sprinta.headhunterbackend.account.dto.AccountDtoView;
 import se.sprinta.headhunterbackend.account.dto.AccountUpdateDtoForm;
+import se.sprinta.headhunterbackend.system.exception.EmailNotFreeException;
 import se.sprinta.headhunterbackend.system.exception.ObjectNotFoundException;
 
 import java.util.List;
@@ -42,9 +43,12 @@ public class AccountService implements UserDetailsService {
                 .orElseThrow(() -> new ObjectNotFoundException("account", email));
     }
 
-    public boolean isEmailAvailable(String email) {
-        return this.accountRepository.isEmailAvailable(email);
+    public boolean checkEmailUnique(String email) {
+        boolean isEmailNotTaken = this.accountRepository.checkEmailUnique(email);
+        if (!isEmailNotTaken) throw new EmailNotFreeException(email);
+        return true;
     }
+
 
     public List<AccountDtoView> getAllAccountDtoViews() {
         return this.accountRepository.getAllAccountDtoViews();

--- a/src/main/java/se/sprinta/headhunterbackend/security/SecurityConfig.java
+++ b/src/main/java/se/sprinta/headhunterbackend/security/SecurityConfig.java
@@ -96,10 +96,11 @@ public class SecurityConfig {
                          */
 
                         .requestMatchers(HttpMethod.GET, this.baseUrlAccount + "/findAll").hasAuthority("ROLE_admin")
-                        .requestMatchers(HttpMethod.GET, this.baseUrlAccount + "/findById/{id}").hasAuthority("ROLE_admin")
+                        .requestMatchers(HttpMethod.GET, this.baseUrlAccount + "/checkEmailUnique/{email}").permitAll()
                         .requestMatchers(HttpMethod.POST, this.baseUrlAccount + "/register").permitAll()
                         .requestMatchers(HttpMethod.PUT, this.baseUrlAccount + "/update/{email}").hasAuthority("ROLE_admin")
                         .requestMatchers(HttpMethod.DELETE, this.baseUrlAccount + "/delete/{email}").hasAuthority("ROLE_admin")
+
 
                         /**
                          * Job requests

--- a/src/main/java/se/sprinta/headhunterbackend/system/StatusCode.java
+++ b/src/main/java/se/sprinta/headhunterbackend/system/StatusCode.java
@@ -15,5 +15,7 @@ public class StatusCode {
 
     public static final int NOT_FOUND = 404; // Not found
 
+    public static final int CONFLICT = 409; // Conflict
+
     public static final int INTERNAL_SERVER_ERROR = 500; // Server internal error
 }

--- a/src/main/java/se/sprinta/headhunterbackend/system/exception/EmailNotFreeException.java
+++ b/src/main/java/se/sprinta/headhunterbackend/system/exception/EmailNotFreeException.java
@@ -1,0 +1,8 @@
+package se.sprinta.headhunterbackend.system.exception;
+
+public class EmailNotFreeException extends RuntimeException {
+
+    public EmailNotFreeException(String email) {
+        super(email + " is already registered");
+    }
+}

--- a/src/main/java/se/sprinta/headhunterbackend/system/exception/ExceptionHandlerAdvice.java
+++ b/src/main/java/se/sprinta/headhunterbackend/system/exception/ExceptionHandlerAdvice.java
@@ -46,6 +46,12 @@ public class ExceptionHandlerAdvice {
         return new Result(false, StatusCode.NOT_FOUND, ex.getMessage());
     }
 
+    @ExceptionHandler(EmailNotFreeException.class)
+    @ResponseStatus(HttpStatus.CONFLICT)
+    Result handleEmailNotFreeException(EmailNotFreeException ex) {
+        return new Result(false, StatusCode.CONFLICT, ex.getMessage());
+    }
+
     @ExceptionHandler(MethodArgumentNotValidException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     Result handleValidationException(MethodArgumentNotValidException ex) {

--- a/src/test/java/se/sprinta/headhunterbackend/account/AccountControllerAuthorityIntegrationMySQLTest.java
+++ b/src/test/java/se/sprinta/headhunterbackend/account/AccountControllerAuthorityIntegrationMySQLTest.java
@@ -104,6 +104,76 @@ public class AccountControllerAuthorityIntegrationMySQLTest {
                 .andExpect(jsonPath("$.data").value("Access Denied"));
     }
 
+    @Test
+    @DisplayName("(GET) - checkEmailUnique - Admin Permission - Non-Existing Email - Success")
+    void test_CheckEmailUnique_AdminPermission_NonExistingEmail_Success() throws Exception {
+        this.mockMvc.perform(get(this.baseUrlAccount + "/checkEmailUnique" + "/availableEmail@hh.se")
+                        .accept(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, adminToken()))
+                .andExpect(jsonPath("$.flag").value(true))
+                .andExpect(jsonPath("$.code").value(StatusCode.SUCCESS))
+                .andExpect(jsonPath("$.message").value("Email is available"))
+                .andExpect(jsonPath("$.data").isEmpty());
+    }
+
+    @Test
+    @DisplayName("(GET) - checkEmailUnique - User Permission - Non-Existing Email - Success")
+    void test_CheckEmailUnique_UserPermission_NonExistingEmail_Success() throws Exception {
+        this.mockMvc.perform(get(this.baseUrlAccount + "/checkEmailUnique" + "/availableEmail@hh.se")
+                        .accept(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, userToken()))
+                .andExpect(jsonPath("$.flag").value(true))
+                .andExpect(jsonPath("$.code").value(StatusCode.SUCCESS))
+                .andExpect(jsonPath("$.message").value("Email is available"))
+                .andExpect(jsonPath("$.data").isEmpty());
+    }
+
+    @Test
+    @DisplayName("(GET) - checkEmailUnique - No Authorization - Non-Existing Email - Success")
+    void test_CheckEmailUnique_NoAuthorization_NonExistingEmail_Success() throws Exception {
+        this.mockMvc.perform(get(this.baseUrlAccount + "/checkEmailUnique" + "/availableEmail@hh.se")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.flag").value(true))
+                .andExpect(jsonPath("$.code").value(StatusCode.SUCCESS))
+                .andExpect(jsonPath("$.message").value("Email is available"))
+                .andExpect(jsonPath("$.data").isEmpty());
+    }
+
+    @Test
+    @DisplayName("(GET) - checkEmailUnique - Admin Permission - Existing Email - Exception")
+    void test_CheckEmailUnique_AdminPermission_ExistingEmail_Exception() throws Exception {
+        this.mockMvc.perform(get(this.baseUrlAccount + "/checkEmailUnique" + "/admin-mysql@hh.se")
+                        .accept(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, adminToken()))
+                .andExpect(jsonPath("$.flag").value(false))
+                .andExpect(jsonPath("$.code").value(StatusCode.CONFLICT))
+                .andExpect(jsonPath("$.message").value("admin-mysql@hh.se is already registered"))
+                .andExpect(jsonPath("$.data").isEmpty());
+    }
+
+    @Test
+    @DisplayName("(GET) - checkEmailUnique - User Permission - Existing Email - Exception")
+    void test_CheckEmailUnique_UserPermission_ExistingEmail_Exception() throws Exception {
+        this.mockMvc.perform(get(this.baseUrlAccount + "/checkEmailUnique" + "/admin-mysql@hh.se")
+                        .accept(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, userToken()))
+                .andExpect(jsonPath("$.flag").value(false))
+                .andExpect(jsonPath("$.code").value(StatusCode.CONFLICT))
+                .andExpect(jsonPath("$.message").value("admin-mysql@hh.se is already registered"))
+                .andExpect(jsonPath("$.data").isEmpty());
+    }
+
+    @Test
+    @DisplayName("(GET) - checkEmailUnique - No Authorization - Existing Email - Exception")
+    void test_CheckEmailUnique_NoAuthorization_ExistingEmail_Exception() throws Exception {
+        this.mockMvc.perform(get(this.baseUrlAccount + "/checkEmailUnique" + "/admin-mysql@hh.se")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.flag").value(false))
+                .andExpect(jsonPath("$.code").value(StatusCode.CONFLICT))
+                .andExpect(jsonPath("$.message").value("admin-mysql@hh.se is already registered"))
+                .andExpect(jsonPath("$.data").isEmpty());
+    }
+
 
     @Test
     @DisplayName("(GET) - getAccountDtoByEmail - Admin Permission - Success")
@@ -156,10 +226,10 @@ public class AccountControllerAuthorityIntegrationMySQLTest {
     }
 
     @Test
-    @DisplayName("(POST) register - Admin No Permission - Exception")
+    @DisplayName("(POST) register - Admin Permission - Exception")
     void test_RegisterAccount_AdminNoPermission_Exception() throws Exception {
         AccountDtoFormRegister accountDtoFormRegister = new AccountDtoFormRegister(
-                "newUser@hh.se",
+                "user4-mysql@hh.se",
                 "a"
         );
 
@@ -168,12 +238,14 @@ public class AccountControllerAuthorityIntegrationMySQLTest {
         this.mockMvc.perform(post(this.baseUrlAccount + "/register")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(json)
-                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
                         .header(HttpHeaders.AUTHORIZATION, adminToken()))
-                .andExpect(jsonPath("$.flag").value(false))
-                .andExpect(jsonPath("$.code").value(StatusCode.FORBIDDEN))
-                .andExpect(jsonPath("$.message").value("No permission"))
-                .andExpect(jsonPath("$.data").value("Access Denied"));
+                .andExpect(jsonPath("$.flag").value(true))
+                .andExpect(jsonPath("$.code").value(StatusCode.SUCCESS))
+                .andExpect(jsonPath("$.message").value("Add Account Success"))
+                .andExpect(jsonPath("$.data.email").value("user4-mysql@hh.se"))
+                .andExpect(jsonPath("$.data.roles").value("user"))
+                .andExpect(jsonPath("$.data.number_of_jobs").value(0));
     }
 
     @Test

--- a/src/test/java/se/sprinta/headhunterbackend/account/AccountRepositoryH2Test.java
+++ b/src/test/java/se/sprinta/headhunterbackend/account/AccountRepositoryH2Test.java
@@ -1,23 +1,55 @@
 package se.sprinta.headhunterbackend.account;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import se.sprinta.headhunterbackend.H2DatabaseInitializer;
 import se.sprinta.headhunterbackend.account.dto.AccountDtoView;
+import se.sprinta.headhunterbackend.ad.Ad;
+import se.sprinta.headhunterbackend.job.Job;
 
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 @DataJpaTest
-@ActiveProfiles("test-h2")
 class AccountRepositoryH2Test {
 
     @Autowired
     private AccountRepository accountRepository;
 
+    @BeforeEach
+    void setUp() {
+        Account admin = new Account();
+        admin.setEmail("admin-h2@hh.se");
+        admin.setPassword("a");
+        admin.setRoles("admin");
 
+        Account user1 = new Account();
+        user1.setEmail("user1-h2@hh.se");
+        user1.setPassword("a");
+        user1.setRoles("user");
+
+        Account user2 = new Account();
+        user2.setEmail("user2-h2@hh.se");
+        user2.setPassword("a");
+        user2.setRoles("user");
+
+        Account user3 = new Account();
+        user3.setEmail("user3-h2@hh.se");
+        user3.setPassword("a");
+        user3.setRoles("user");
+
+        this.accountRepository.save(admin);
+        this.accountRepository.save(user1);
+        this.accountRepository.save(user2);
+        this.accountRepository.save(user3);
+    }
 
     @Test
     void test_findAccountByEmail() {
@@ -38,5 +70,19 @@ class AccountRepositoryH2Test {
             assertEquals(foundAccountDtoView.get().email(), "admin-h2@hh.se");
             assertEquals(foundAccountDtoView.get().roles(), "admin");
         }
+    }
+
+    @Test
+    @DisplayName("checkEmailUnique - Email Exist")
+    void test_CheckEmailUnique_Success() {
+        boolean numberOfEmailInputInInDatabase = this.accountRepository.checkEmailUnique("admin-h2@hh.se");
+        assertFalse(numberOfEmailInputInInDatabase);
+    }
+
+    @Test
+    @DisplayName("checkEmailUnique - Email Does not Exist")
+    void test_CheckEmailUnique_InvalidInput() {
+        boolean numberOfEmailInputInInDatabase = this.accountRepository.checkEmailUnique("availableEmail@hh.se");
+        assertTrue(numberOfEmailInputInInDatabase);
     }
 }

--- a/src/test/java/se/sprinta/headhunterbackend/account/AccountServiceH2Test.java
+++ b/src/test/java/se/sprinta/headhunterbackend/account/AccountServiceH2Test.java
@@ -9,12 +9,14 @@ import se.sprinta.headhunterbackend.H2DatabaseInitializer;
 import se.sprinta.headhunterbackend.account.dto.AccountDtoFormRegister;
 import se.sprinta.headhunterbackend.account.dto.AccountDtoView;
 import se.sprinta.headhunterbackend.account.dto.AccountUpdateDtoForm;
+import se.sprinta.headhunterbackend.system.exception.EmailNotFreeException;
 import se.sprinta.headhunterbackend.system.exception.ObjectNotFoundException;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
 
 @SpringBootTest
 @ActiveProfiles("test-h2")
@@ -73,13 +75,33 @@ public class AccountServiceH2Test {
 
     @Test
     @DisplayName("findById - Invalid Input - Exception")
-    void test_FindById_InvalidInput_Success() {
+    void test_FindById_InvalidInput_Exception() {
         Throwable thrown = assertThrows(ObjectNotFoundException.class,
                 () -> this.accountService.findById("Invalid Email"));
 
         assertThat(thrown)
                 .isInstanceOf(ObjectNotFoundException.class)
                 .hasMessage("Could not find account with Email Invalid Email");
+    }
+
+    @Test
+    @DisplayName("checkEmailUnique - Non-Existing Email - Success")
+    void test_CheckEmailUnique_NonExistingEmail_ReturnsTrue_Success() {
+        boolean isEmailNotAvailableInDatabase = this.accountService.checkEmailUnique("availableEmail@hh.se");
+
+        assertTrue(isEmailNotAvailableInDatabase);
+    }
+
+    @Test
+    @DisplayName("checkEmailUnique - Existing Email - Exception")
+    void test_CheckEmailUnique_ExistingEmail_Exception() {
+        Throwable thrown = assertThrows(EmailNotFreeException.class,
+                () -> this.accountService.checkEmailUnique("admin-h2@hh.se"));
+
+        assertThat(thrown)
+                .isInstanceOf(EmailNotFreeException.class)
+                .hasMessage("admin-h2@hh.se is already registered");
+
     }
 
     @Test

--- a/src/test/java/se/sprinta/headhunterbackend/account/AccountServiceMockTest.java
+++ b/src/test/java/se/sprinta/headhunterbackend/account/AccountServiceMockTest.java
@@ -9,6 +9,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import se.sprinta.headhunterbackend.account.dto.AccountDtoFormRegister;
+import se.sprinta.headhunterbackend.system.exception.EmailNotFreeException;
 import se.sprinta.headhunterbackend.system.exception.ObjectNotFoundException;
 import se.sprinta.headhunterbackend.account.dto.AccountDtoView;
 import se.sprinta.headhunterbackend.account.dto.AccountUpdateDtoForm;
@@ -18,8 +19,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentCaptor.*;
 import static org.mockito.BDDMockito.*;
 
@@ -50,6 +50,33 @@ class AccountServiceMockTest {
 
         // Verify
         then(this.accountRepository).should().findAll();
+    }
+
+    @Test
+    @DisplayName("checkEmailUnique - Non-Existing Email")
+    void test_CheckEmailUnique_NonExistingEmail_ReturnsTrue_Success() {
+        // Given
+        given(this.accountRepository.checkEmailUnique("availableEmail@hh.se")).willReturn(true);
+
+        // When
+        boolean isEmailNotAvailableInDatabase = this.accountService.checkEmailUnique("availableEmail@hh.se");
+
+        // Then
+        assertTrue(isEmailNotAvailableInDatabase);
+    }
+
+    @Test
+    @DisplayName("checkEmailUnique - Existing Email - Exception")
+    void test_CheckEmailUnique_ExistingEmail_Exception() {
+        // Given
+        given(this.accountRepository.checkEmailUnique("admin@hh.se")).willReturn(false);
+
+        Throwable thrown = assertThrows(EmailNotFreeException.class,
+                () -> this.accountService.checkEmailUnique("admin@hh.se"));
+
+        assertThat(thrown)
+                .isInstanceOf(EmailNotFreeException.class)
+                .hasMessage("admin@hh.se is already registered");
     }
 
 


### PR DESCRIPTION
When a user tries to register a new Email, that email cannot already exist in the db.

The user sends a request to account/checkEmailUnique/{email}. If the email is not already registered, the response includes a true flag. If the email is already registered, a EmailNotFreeException() will get thrown. Method added to repo, service, and controller layer. Tests for each layer.